### PR TITLE
fix wrong exit code on main protect example

### DIFF
--- a/hooks_example/pre-push-main-protect
+++ b/hooks_example/pre-push-main-protect
@@ -14,6 +14,7 @@ if [ $current_branch = 'main' ] || [ $current_branch = 'master' ]; then
     echo
     if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
         run_local_hook
+	exit 0
     fi
     exit 1
 fi


### PR DESCRIPTION
The hook was considered as always failing since the exit code was finally 1 instead of 0.